### PR TITLE
User can toggle their push notifications on/off

### DIFF
--- a/app/src/main/java/com/alana/wheretonext/MainActivity.java
+++ b/app/src/main/java/com/alana/wheretonext/MainActivity.java
@@ -11,6 +11,7 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -55,7 +56,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        startNotificationReceiver();
+        SharedPreferences sharedPrefs = this.getSharedPreferences("com.alana.wheretonext", Context.MODE_PRIVATE);
+        Boolean notifsToggled = sharedPrefs.getBoolean("NotifSwitch", true);
+
+        if (notifsToggled)
+        {
+            scheduleNotificationReceiver();
+        }
 
         toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -141,7 +148,20 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
     }
 
-    public void startNotificationReceiver() {
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        SharedPreferences sharedPrefs = this.getSharedPreferences("com.alana.wheretonext", Context.MODE_PRIVATE);
+        Boolean notifsToggled = sharedPrefs.getBoolean("NotifSwitch", true);
+
+        if (notifsToggled)
+        {
+            scheduleNotificationReceiver();
+        }
+    }
+
+    public void scheduleNotificationReceiver() {
 
         Intent alarmIntent = new Intent(this, NotificationReceiver.class);
         PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, alarmIntent, 0);
@@ -150,8 +170,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         Calendar calendar = Calendar.getInstance();
         calendar.setTimeInMillis(System.currentTimeMillis());
-        calendar.set(Calendar.HOUR_OF_DAY, 12);
-        calendar.set(Calendar.MINUTE, 52);
+        calendar.set(Calendar.HOUR_OF_DAY, 1);
+        calendar.set(Calendar.MINUTE, 49);
         calendar.set(Calendar.SECOND, 1);
 
         long INTERVAL_WEEK = AlarmManager.INTERVAL_DAY;

--- a/app/src/main/java/com/alana/wheretonext/ui/settings/NotificationSettingsActivity.java
+++ b/app/src/main/java/com/alana/wheretonext/ui/settings/NotificationSettingsActivity.java
@@ -5,9 +5,13 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.widget.CompoundButton;
 import android.widget.Switch;
+import android.widget.Toast;
 
 import com.alana.wheretonext.R;
+import com.alana.wheretonext.data.models.FavoritePhrase;
+import com.alana.wheretonext.service.NotificationService;
 
 public class NotificationSettingsActivity extends AppCompatActivity {
 
@@ -19,10 +23,26 @@ public class NotificationSettingsActivity extends AppCompatActivity {
 
         notifSwitch = findViewById(R.id.notifSwitch);
 
-        // TODO: Update this so that notifications only show if the user wants them
-        SharedPreferences sharedPreferences = getSharedPreferences("com.alana.wheretonext", Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putBoolean("NotifSwitch", notifSwitch.isChecked());
-        editor.apply();
+        SharedPreferences sharedPrefs = getSharedPreferences("com.alana.wheretonext", MODE_PRIVATE);
+        notifSwitch.setChecked(sharedPrefs.getBoolean("NotifSwitch", true));
+
+        notifSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                if (isChecked) {
+                    SharedPreferences.Editor editor = getSharedPreferences("com.alana.wheretonext", MODE_PRIVATE).edit();
+                    editor.putBoolean("NotifSwitch", true);
+                    editor.commit();
+
+                    Toast.makeText(getApplicationContext(), "Push notifications turned on.", Toast.LENGTH_SHORT).show();
+                } else {
+                    SharedPreferences.Editor editor = getSharedPreferences("com.alana.wheretonext", MODE_PRIVATE).edit();
+                    editor.putBoolean("NotifSwitch", false);
+                    editor.commit();
+
+                    Toast.makeText(getApplicationContext(), "Push notifications turned off.", Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
User can toggle their push notifications on/off using SharedPreferences.
Tested using Android phone. Checked whether or not a notification showed up at the expected time, given the state of the Switch button.